### PR TITLE
Fix IE, 'BACK_COMPAT' is undefined errors.

### DIFF
--- a/src/js/host/host.js
+++ b/src/js/host/host.js
@@ -956,7 +956,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
     			if (!use_brute && BOUNDING && el[BOUNDING]) {
                 	if (isIE) {
-						if (!docMode || (docMode > 0 && docMode < 8) || compatMode === BACK_COMPAT) {
+						if (!docMode || (docMode > 0 && docMode < 8) || compatMode === 'BackCompat') {
 							offX = root.clientLeft;
 							offY = root.clientTop;
                         }


### PR DESCRIPTION
Definition of BACK_COMPAT is missing.
Just use the string value, it's not used anywhere else and  'CSS1Compat' is also used like this.
