### PR TITLE
Override iframe max width height

### DIFF
--- a/src/js/host/host.js
+++ b/src/js/host/host.js
@@ -956,7 +956,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
     			if (!use_brute && BOUNDING && el[BOUNDING]) {
                 	if (isIE) {
-						if (!docMode || (docMode > 0 && docMode < 8) || compatMode === BACK_COMPAT) {
+						if (!docMode || (docMode > 0 && docMode < 8) || compatMode === 'BackCompat') {
 							offX = root.clientLeft;
 							offY = root.clientTop;
                         }

--- a/src/js/host/host.js
+++ b/src/js/host/host.js
@@ -3030,7 +3030,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 			args		= arguments,
 			firstCSSPos = "relative",
 			finalCSSPos = "absolute",
-			finalCSSEnd = "top:0px;left:0px;visibility:hidden;display:none;",
+			finalCSSEnd = "top:0px;left:0px;visibility:hidden;display:none;max-width:none;max-height:none;",
 
 		pos, pos_id, pos_conf, dest_el, new_dest_el, rel_el, par_el,
 		name_params, dest_id, dest_rel_id, css_txt, w, h, st, e, pend,


### PR DESCRIPTION
When the safeframe host website has css rule 'iframe {max-width: 100%'}, expansion doesn't work properly.
Setting max-width and max-height on the generated iframe worksaround this issue.
