### PR TITLE
Fix - Handle when outside message event.data is not a string

### DIFF
--- a/src/js/host/host.js
+++ b/src/js/host/host.js
@@ -1726,7 +1726,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 	{
 		var data		= evt && evt.data,
 			msg_win		= evt && evt.source,
-			params		= data && (data.indexOf(GUID) != -1) && ParamHash(data),
+			params		= data && typeof data == STR && (data.indexOf(GUID) != -1) && ParamHash(data),
 			tgtID 		= params && params.id,
 			ifr			= tgtID && _elt(tgtID),
 			fr_win		= ifr && _ifr_view(ifr),


### PR DESCRIPTION
Fixed issue when outside message data was not a string.

Steps to reproduce:

1. Load page with safeframe
2. Open web developer tools console
3. Type `window.postMessage({}, "*")` and enter

Result:
```
Uncaught TypeError: data.indexOf is not a function
    at _handle_msg_from_outside (host.js:1729)
```

Expected result:
```
No error and message should be ignored
```